### PR TITLE
Updated the build.gradle

### DIFF
--- a/packages/image_picker/android/build.gradle
+++ b/packages/image_picker/android/build.gradle
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.android.support:appcompat-v7:27.1.0'
+    api 'com.android.support:appcompat-v7:27.1.1'
 }


### PR DESCRIPTION
The version of the appcompat-v7 from the image_picker library differs from the path_provider plugin causing a build conflict when used together. Updated the image_picker library to same version as path_provider.